### PR TITLE
Stop zooming on button clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Webpage of Ben</title>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
 
     <style>
       body {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Webpage of Ben</title>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <style>
       body {
@@ -11,6 +11,7 @@
 
       button {
         cursor: pointer;
+        touch-action: manipulation;
       }
 
       main {


### PR DESCRIPTION
Stop zooming in when tapping on buttons so that galleries can be navigated without having to zoom back out