### PR TITLE
Vertically center gallery arrows alongside the image

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -69,17 +69,17 @@ figcaption {
 .fesh-gallery .controls {
   display: flex;
   justify-content: space-between;
+  position: absolute;
+  top: 50%;
+  left: 0;
   width: 100%;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 .fesh-gallery .controls button {
   background-color: transparent;
   border: 0;
   font-size: 3em;
   padding: 0;
-}
-.fesh-gallery .controls button.prev {
-  left: 0;
-}
-.fesh-gallery .controls button.next {
-  right: 0;
+  pointer-events: all;
 }


### PR DESCRIPTION
## Summary

- The gallery navigation arrows were rendering below the image in DOM order rather than alongside it
- Switches `.fesh-gallery .controls` to `position: absolute` with `top: 50%` / `translateY(-50%)` to center them vertically over the image
- Works on both mobile and desktop

## Test plan

- Open `index.html` in a browser
- Verify the ⬅️ and ➡️ arrows appear vertically centered beside the gallery image, not below it
- Resize to mobile width and confirm arrows remain centered