### PR TITLE
Allow custom arrows on image galleries

### DIFF
--- a/images/SB/arrow-left.svg
+++ b/images/SB/arrow-left.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 50">
+  <defs>
+    <filter id="shadow-l" x="-15%" y="-15%" width="130%" height="130%">
+      <feDropShadow dx="1" dy="2" stdDeviation="1.5" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+  <!-- Wood body -->
+  <polygon points="0,25 22,0 22,14 78,14 78,36 22,36 22,50"
+           fill="#A0714F" stroke="#5C3317" stroke-width="1.5"
+           stroke-linejoin="round" filter="url(#shadow-l)"/>
+  <!-- Top-face highlight for depth -->
+  <polygon points="1,25 22,1.5 22,14 78,14 78,15 22,15 22,2.5"
+           fill="#C4965A" opacity="0.35"/>
+  <!-- Wood grain lines -->
+  <line x1="23" y1="18" x2="77" y2="18" stroke="#6B3F1E" stroke-width="0.8" opacity="0.45"/>
+  <line x1="23" y1="22" x2="77" y2="22" stroke="#6B3F1E" stroke-width="0.8" opacity="0.3"/>
+  <line x1="23" y1="28" x2="77" y2="28" stroke="#6B3F1E" stroke-width="0.8" opacity="0.3"/>
+  <line x1="23" y1="32" x2="77" y2="32" stroke="#6B3F1E" stroke-width="0.8" opacity="0.45"/>
+  <!-- Nail head -->
+  <circle cx="50" cy="25" r="5.5" fill="#9A9A9A" stroke="#555" stroke-width="1"/>
+  <circle cx="50" cy="25" r="3"   fill="#777"/>
+  <!-- Nail highlight -->
+  <circle cx="48.5" cy="23.5" r="1.2" fill="#D8D8D8" opacity="0.85"/>
+</svg>

--- a/images/SB/arrow-right.svg
+++ b/images/SB/arrow-right.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 50">
+  <defs>
+    <filter id="shadow-r" x="-15%" y="-15%" width="130%" height="130%">
+      <feDropShadow dx="1" dy="2" stdDeviation="1.5" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+  <!-- Wood body -->
+  <polygon points="80,25 58,0 58,14 2,14 2,36 58,36 58,50"
+           fill="#A0714F" stroke="#5C3317" stroke-width="1.5"
+           stroke-linejoin="round" filter="url(#shadow-r)"/>
+  <!-- Top-face highlight for depth -->
+  <polygon points="79,25 58,1.5 58,14 2,14 2,15 58,15 58,2.5"
+           fill="#C4965A" opacity="0.35"/>
+  <!-- Wood grain lines -->
+  <line x1="3"  y1="18" x2="57" y2="18" stroke="#6B3F1E" stroke-width="0.8" opacity="0.45"/>
+  <line x1="3"  y1="22" x2="57" y2="22" stroke="#6B3F1E" stroke-width="0.8" opacity="0.3"/>
+  <line x1="3"  y1="28" x2="57" y2="28" stroke="#6B3F1E" stroke-width="0.8" opacity="0.3"/>
+  <line x1="3"  y1="32" x2="57" y2="32" stroke="#6B3F1E" stroke-width="0.8" opacity="0.45"/>
+  <!-- Nail head -->
+  <circle cx="30" cy="25" r="5.5" fill="#9A9A9A" stroke="#555" stroke-width="1"/>
+  <circle cx="30" cy="25" r="3"   fill="#777"/>
+  <!-- Nail highlight -->
+  <circle cx="28.5" cy="23.5" r="1.2" fill="#D8D8D8" opacity="0.85"/>
+</svg>

--- a/scripts/fesh.js
+++ b/scripts/fesh.js
@@ -15,7 +15,17 @@
 
   const getActiveImage = (container) => container.querySelector('a.active');
 
-  const gallery = (selector, files) => {
+  const createControlContent = (content) => {
+    if (content && typeof content === 'object' && content.src) {
+      const img = document.createElement('img');
+      img.setAttribute('src', content.src);
+      img.setAttribute('alt', content.alt || '');
+      return img;
+    }
+    return document.createTextNode(content);
+  };
+
+  const gallery = (selector, files, options = {}) => {
     const target = document.querySelector(selector);
     const [firstFile, ...otherFiles] = files;
     const firstImage = createImage(firstFile);
@@ -23,6 +33,9 @@
     const controlsContainer = document.createElement('div');
     const nextControl = document.createElement('button');
     const prevControl = document.createElement('button');
+
+    const prevContent = options.prev !== undefined ? options.prev : '⬅️';
+    const nextContent = options.next !== undefined ? options.next : '➡️';
 
     target.classList.add('fesh-gallery');
     controlsContainer.classList.add('controls');
@@ -37,7 +50,7 @@
     target.appendChild(imageContainer);
 
     prevControl.classList.add('prev');
-    prevControl.appendChild(document.createTextNode('⬅️'));
+    prevControl.appendChild(createControlContent(prevContent));
     prevControl.addEventListener('click', () => {
       const currentActive = getActiveImage(target);
       const nextActive = imageContainer.firstChild === currentActive ? imageContainer.lastChild : currentActive.previousSibling;
@@ -48,7 +61,7 @@
     controlsContainer.appendChild(prevControl);
 
     nextControl.classList.add('next');
-    nextControl.appendChild(document.createTextNode('➡️'));
+    nextControl.appendChild(createControlContent(nextContent));
     nextControl.addEventListener('click', () => {
       const currentActive = getActiveImage(target);
       const nextActive = imageContainer.lastChild === currentActive ? imageContainer.firstChild : currentActive.nextSibling;

--- a/spongebob.html
+++ b/spongebob.html
@@ -558,7 +558,10 @@
         './images/SB/character_montage.png',
         './images/SB/parade.jpg',
         './images/SB/krakow.jpg',
-      ]);
+      ], {
+        prev: { src: './images/SB/arrow-left.svg',  alt: 'Previous image' },
+        next: { src: './images/SB/arrow-right.svg', alt: 'Next image' },
+      });
 
       (function () {
         const trivia = [

--- a/styles/main.css
+++ b/styles/main.css
@@ -83,3 +83,8 @@ figcaption {
   padding: 0;
   pointer-events: all;
 }
+.fesh-gallery .controls button img {
+  height: 1em;
+  width: auto;
+  display: block;
+}


### PR DESCRIPTION
## Summary

- `fesh.gallery()` now accepts an optional third `options` argument with `prev` and `next` keys — each can be a string/emoji (existing behavior, still the default) or an `{ src, alt }` object to use an image
- All existing call sites are unaffected
- Added CSS to size image-based arrows consistently with emoji arrows
- SpongeBob gallery uses new wooden sign SVG arrows (grain lines, nail head, highlight edge) to match the Bikini Bottom aesthetic

## Test plan

- Open `index.html` — gallery arrows should still show ⬅️ ➡️ as before
- Open `spongebob.html` — gallery arrows should show the wooden sign SVGs
- Verify arrows are vertically centered alongside the image on both desktop and mobile
- Confirm prev/next navigation still works with the custom arrows